### PR TITLE
Adding msg.port to input and some docs

### DIFF
--- a/ezo.html
+++ b/ezo.html
@@ -26,18 +26,18 @@
 <script type="text/html" data-help-name="ezo">
     <h3>Details</h3>
     <p>
-        Communicates with Atlas Scientific Ezo modules over I2C.
-        See manufacturers documentation for supported commands.
+        Communicates with Atlas Scientific Ezo modules over I2C. See manufacturers documentation for supported commands.
     </p>
     <p>
-        Input accepts a string in <code>msg.payload</code>, 
-        sends to device as Buffer, then outputs the response.
+        <strong>Input</strong> accepts a string in <code>msg.payload</code>, sends to device as Buffer, then outputs the response. Input also optionally accepts two additional properties which are useful for dynamic flows:
+        <ul>
+            <li><code>msg.address</code> which, if present, will override the node‘s default or user-defined address
+            </li>
+            <li><code>msg.port</code> which, if present, will override the default `/dev/i2c-1` port. For example, setting this to `11` would result in the node using `/dev/i2c-11`.</li>
+        </ul>
     </p>
     <p>
-        Response is broken into three properties: <code>msg.status</code>
-         stores the response status with message, <code>msg.command</code>
-         stores the initial command, and <code>msg.payload</code>
-         stores the response value(s).
+        <strong>Response</strong> is broken into three properties: <code>msg.status</code> stores the response status with message, <code>msg.command</code> stores the initial command, and <code>msg.payload</code> stores the response value(s).
     </p>
     <h3>References</h3>
     <ul>
@@ -63,35 +63,87 @@
 </script>
 
 <script type="text/javascript">
-    var values = [
-        {v:"ph", t:"pH", tp:'ph'},
-        {v:"orp", t:"ORP", tp:'orp'},
-        {v:"do", t:"Dissolved Oxygen", tp:'dissolved_oxygen'},
-        {v:"ec", t:"Conductivity", tp:'conductivity'},
-        {v:"rtd", t:"Temperature", tp:'temperature'},
-        {v:"co2", t:"Carbon Dioxide", tp:'carbon_dioxide'},
-        {v:"o2", t:"Oxygen", tp:'oxygen'},
-        {v:"hum", t:"Humidity", tp:'humidity'},
-        {v:"prs", t:"Pressure", tp:'pressure'},
-        {v:"pmp", t:"Peristaltic", tp:'peristaltic'},
-        {v:"pmp-l", t:"Peristaltic - Large", tp:'peristaltic_large'},
-        {v:"rgb", t:"Color", tp:'color'},
-        {v:"flo", t:"Flow", tp:'flow'},
-    ];
+    var values = [{
+        v: "ph",
+        t: "pH",
+        tp: 'ph'
+    }, {
+        v: "orp",
+        t: "ORP",
+        tp: 'orp'
+    }, {
+        v: "do",
+        t: "Dissolved Oxygen",
+        tp: 'dissolved_oxygen'
+    }, {
+        v: "ec",
+        t: "Conductivity",
+        tp: 'conductivity'
+    }, {
+        v: "rtd",
+        t: "Temperature",
+        tp: 'temperature'
+    }, {
+        v: "co2",
+        t: "Carbon Dioxide",
+        tp: 'carbon_dioxide'
+    }, {
+        v: "o2",
+        t: "Oxygen",
+        tp: 'oxygen'
+    }, {
+        v: "hum",
+        t: "Humidity",
+        tp: 'humidity'
+    }, {
+        v: "prs",
+        t: "Pressure",
+        tp: 'pressure'
+    }, {
+        v: "pmp",
+        t: "Peristaltic",
+        tp: 'peristaltic'
+    }, {
+        v: "pmp-l",
+        t: "Peristaltic - Large",
+        tp: 'peristaltic_large'
+    }, {
+        v: "rgb",
+        t: "Color",
+        tp: 'color'
+    }, {
+        v: "flo",
+        t: "Flow",
+        tp: 'flow'
+    }, ];
     RED.nodes.registerType('ezo', {
         category: 'ezo',
         defaults: {
-            name: { value: '' },
-            address: { value: 3, validate: function (v) { return ((v === 3) || (RED.validators.number(v) && (v >= 3) && (v <= 127))) } },
-            customAddr: { value: false },
-            ezoBoard: { value: '', required: true },
-            ezoTopic: { value: '' },
+            name: {
+                value: ''
+            },
+            address: {
+                value: 3,
+                validate: function(v) {
+                    return ((v === 3) || (RED.validators.number(v) && (v >= 3) && (v <= 127)))
+                }
+            },
+            customAddr: {
+                value: false
+            },
+            ezoBoard: {
+                value: '',
+                required: true
+            },
+            ezoTopic: {
+                value: ''
+            },
         },
-        color:"#54A769",
-        inputs:1,
-        outputs:1,
+        color: "#54A769",
+        inputs: 1,
+        outputs: 1,
         icon: "serial.png",
-        label: function() { 
+        label: function() {
             var valueText = "";
             for (var i = 0; i < values.length; i++) {
                 if (values[i].v === this.ezoBoard) {
@@ -102,7 +154,9 @@
             }
             return this.name || valueText || "ezo";
         },
-        labelStyle: function() { return this.name ? "node_label_italic" : ""; },
+        labelStyle: function() {
+            return this.name ? "node_label_italic" : "";
+        },
         oneditprepare: function() {
             for (var i = 0; i < values.length; i++) {
                 var value = values[i].v;
@@ -110,11 +164,10 @@
                 $('#node-input-ezoBoard').append($("<option></option>").attr("value", value).text(text));
             }
             $('#node-input-ezoBoard').val(this.ezoBoard);
-            $('#node-input-customAddr').on("change", function () {
+            $('#node-input-customAddr').on("change", function() {
                 if ($(this)[0].checked) {
                     $('.addr-row').show();
-                }
-                else {
+                } else {
                     $('.addr-row').hide();
                 }
             });

--- a/ezo.js
+++ b/ezo.js
@@ -7,7 +7,7 @@ module.exports = function(RED) {
         if (config.customAddr) {
             this.address = parseInt(config.address);
         } else {
-            switch(config.ezoBoard) {
+            switch (config.ezoBoard) {
                 case 'ph':
                     this.address = 99;
                     break;
@@ -72,13 +72,13 @@ module.exports = function(RED) {
                 newStr = `${c},${p}`;
             } else if (c !== '') {
                 newStr = c;
-            } else if (p !== '') {             
+            } else if (p !== '') {
                 newStr = p;
             }
             return newStr;
         }
         node.processResponse = (res) => {
-            var converted = { command: '', value: ''};
+            var converted = { command: '', value: '' };
             var resString = res.toString('utf8', 1).replace(/\0/g, '');
             if (resString !== '') {
                 if (resString.indexOf(',') !== -1) {
@@ -90,10 +90,10 @@ module.exports = function(RED) {
                     }
                     converted.value = [];
                     for (var i = stp; i < splt.length; i++) {
-                        if (splt[i] === '') { 
-                            converted.value.push( '' );
+                        if (splt[i] === '') {
+                            converted.value.push('');
                         } else {
-                            converted.value.push( isNaN(splt[i]) ? splt[i] : parseFloat(splt[i]) );
+                            converted.value.push(isNaN(splt[i]) ? splt[i] : parseFloat(splt[i]));
                         };
                     }
                 } else {
@@ -108,12 +108,13 @@ module.exports = function(RED) {
         node.on("input", function(msg) {
             var pload = node.processRequest(msg);
             var addr = msg.address || node.address;
+            var portNumber = +msg.port || 1;
             if (pload.length > 32) {
                 node.error('Invalid payload!');
                 return;
             }
             var buf = Buffer.from(pload);
-            var port = I2C.openSync(1);
+            var port = I2C.openSync(portNumber);
             port.i2cWrite(addr, buf.length, buf, function(err) {
                 if (err) {
                     node.errorHandler(port, err, msg);


### PR DESCRIPTION
I thought that maybe also adding `msg.port` could be useful for dynamic flows. For example, I have a case where I'm using a I2C port expander. However, note that I wasn't able to test this code as my current setup has my EZO devices on the normal `/dev/i2c-1` port.